### PR TITLE
docs: 修复 README 折叠块结构并补全 .gitignore 忽略项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # 开发环境
 *.code-workspace
+.DS_Store
 .claude/
 .playwright-mcp/
 .local-private/
@@ -10,6 +11,7 @@
 .trellis/.runtime/
 .trellis/tasks/
 .venv/
+.zcode/
 /output/
 .coverage
 coverage.xml

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@
 
 **环境要求：** Python 3.13.14+，Git
 
-### <summary>Windows 使用</summary>
 <details>
+<summary>Windows 使用</summary>
 
 克隆、安装依赖、运行源码：
 ```bash
@@ -58,8 +58,8 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 ```
 </details>
 
-### <summary>macOS 使用</summary>
 <details>
+<summary>macOS 使用</summary>
 
 当前暂未提供 macOS 安装包，可以通过源码运行：
 ```bash


### PR DESCRIPTION
## 简述改动

- **README.md**：「从源码运行」一节 Windows / macOS 两个折叠块的 `<summary>` 原先写在 `<details>` 外面并套在 `###` 标题里，GitHub 上渲染成怪异标题 + 无标题的默认折叠块。已移回 `<details>` 内部，现在正常显示为「Windows 使用」「macOS 使用」可折叠分组。
- **.gitignore**：新增 `.DS_Store` 与 `.zcode/`。仓库根目录当前就有一个未跟踪的 `.DS_Store`；`.zcode/` 与已忽略的 `.claude/`、`.agent/` 同属 AI 工具工作目录。避免 macOS 贡献者与 AI 编码工具误提交垃圾文件。

## 影响

- 纯文档与忽略规则调整，不涉及任何运行时代码，无用户可见行为变化（README 渲染除外）。

## 解决的问题

Fixes #106

## 检查

- 本地 `uv run python CI/python_ci.py` 全绿（compile / Ruff / Pyright / 单测，改动前基线）。
- 改动仅 README.md 与 .gitignore，不影响 CI 检查对象。