### PR TITLE
fix: 修正关于页贡献者 GitHub 用户名拼写（shiahonb777 → shiaho777）

### DIFF
--- a/software/ui/pages/more/about.py
+++ b/software/ui/pages/more/about.py
@@ -193,7 +193,7 @@ class AboutPage(ScrollArea):
         contributors_layout = QHBoxLayout()
         contributors_layout.addWidget(BodyLabel("贡献者：", self))
         contributor1_link = HyperlinkButton("https://github.com/hungryM0", "@HUNGRY_M0", self)
-        contributor2_link = HyperlinkButton("https://github.com/shiahonb777", "@shiahonb777", self)
+        contributor2_link = HyperlinkButton("https://github.com/shiaho777", "@shiaho777", self)
         contributor3_link = HyperlinkButton("https://github.com/BingBuLiang", "@BingBuLiang", self)
         contributor4_link = HyperlinkButton("https://github.com/dAwn-Rebirth", "@dAwn-Rebirth", self)
         contributor5_link = HyperlinkButton("https://github.com/Moyuin-aka", "@Moyuin-aka", self)


### PR DESCRIPTION
## 简述改动

`software/ui/pages/more/about.py` 贡献者列表第二项的链接与显示名 `shiahonb777` 多了一个 `n`，指向不存在的 GitHub 用户，应用「关于」页点击会 404。已改为 `@shiaho777`，与 README 贡献者列表一致。

## 影响

仅「更多 → 关于」页面的一个超链接目标，无其他行为变化。

## 解决的问题

Fixes #108

## 检查

- 单行字符串常量修改，本地快速检查（compile / Ruff / Pyright / 单测）通过。