### PR TITLE
test: 补齐腾讯问卷多选约束逻辑单测并修复越界优先级索引缺陷

### DIFF
--- a/CI/unit_tests/providers/test_tencent_answering_rules.py
+++ b/CI/unit_tests/providers/test_tencent_answering_rules.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+
+from tencent.provider.answering_rules import apply_multiple_constraints, normalize_selected_indices
+
+
+class TencentAnsweringRulesTests:
+    def test_normalize_selected_indices_deduplicates_sorts_and_filters_out_of_range(self) -> None:
+        assert normalize_selected_indices([2, 2, -1, 1, 5, 0, 1], 3) == [0, 1, 2]
+
+    def test_normalize_selected_indices_skips_values_that_cannot_be_parsed_as_int(self) -> None:
+        assert normalize_selected_indices(["a", None, "", 1], 4) == [1]
+
+    def test_normalize_selected_indices_returns_empty_for_no_valid_input(self) -> None:
+        assert normalize_selected_indices([], 3) == []
+        assert normalize_selected_indices([-5, 99], 3) == []
+
+    def test_apply_removes_blocked_selection_and_appends_missing_required(self) -> None:
+        result = apply_multiple_constraints(
+            selected_indices=[0, 1],
+            option_count=4,
+            min_required=1,
+            max_allowed=3,
+            required_indices=[2],
+            blocked_indices=[1],
+            positive_priority_indices=[],
+        )
+
+        assert result == [0, 2]
+
+    def test_apply_truncates_to_max_allowed_while_keeping_required(self) -> None:
+        result = apply_multiple_constraints(
+            selected_indices=[3, 2, 1],
+            option_count=5,
+            min_required=1,
+            max_allowed=2,
+            required_indices=[4],
+            blocked_indices=[],
+            positive_priority_indices=[],
+        )
+
+        assert result == [1, 4]
+
+    def test_apply_fills_to_min_required_preferring_positive_priorities(self) -> None:
+        result = apply_multiple_constraints(
+            selected_indices=[],
+            option_count=6,
+            min_required=3,
+            max_allowed=5,
+            required_indices=[0],
+            blocked_indices=[5],
+            positive_priority_indices=[4, 2],
+        )
+
+        assert result == [0, 2, 4]
+
+    def test_apply_caps_result_when_min_required_exceeds_max_allowed(self) -> None:
+        result = apply_multiple_constraints(
+            selected_indices=[],
+            option_count=5,
+            min_required=4,
+            max_allowed=2,
+            required_indices=[],
+            blocked_indices=[],
+            positive_priority_indices=[],
+        )
+
+        assert result == [0, 1]
+
+    def test_apply_clamps_limits_to_option_count(self) -> None:
+        result = apply_multiple_constraints(
+            selected_indices=[],
+            option_count=2,
+            min_required=0,
+            max_allowed=99,
+            required_indices=[],
+            blocked_indices=[],
+            positive_priority_indices=[],
+        )
+
+        assert result == [0]
+
+    def test_apply_ignores_out_of_range_priorities_without_starving_min_fill(self) -> None:
+        result = apply_multiple_constraints(
+            selected_indices=[],
+            option_count=2,
+            min_required=2,
+            max_allowed=2,
+            required_indices=[],
+            blocked_indices=[],
+            positive_priority_indices=[9, -3],
+        )
+
+        assert result == [0, 1]
+
+    def test_apply_required_wins_when_required_overlaps_blocked(self) -> None:
+        result = apply_multiple_constraints(
+            selected_indices=[1],
+            option_count=3,
+            min_required=1,
+            max_allowed=3,
+            required_indices=[1],
+            blocked_indices=[1],
+            positive_priority_indices=[],
+        )
+
+        assert result == [1]

--- a/tencent/provider/answering_rules.py
+++ b/tencent/provider/answering_rules.py
@@ -29,6 +29,7 @@ def apply_multiple_constraints(
 ) -> list[int]:
     blocked = set(normalize_selected_indices(blocked_indices, option_count))
     required = normalize_selected_indices(required_indices, option_count)
+    priorities = normalize_selected_indices(positive_priority_indices, option_count)
     selected = [idx for idx in normalize_selected_indices(selected_indices, option_count) if idx not in blocked]
     for idx in required:
         if idx not in selected:
@@ -46,7 +47,7 @@ def apply_multiple_constraints(
             kept.append(idx)
         selected = normalize_selected_indices(kept, option_count)
     if len(selected) < min_required:
-        for idx in list(positive_priority_indices) + list(range(option_count)):
+        for idx in priorities + list(range(option_count)):
             if idx in blocked or idx in selected:
                 continue
             selected.append(idx)


### PR DESCRIPTION
## 简述改动

- **新增 `CI/unit_tests/providers/test_tencent_answering_rules.py`（10 个用例）**：锁定 `tencent/provider/answering_rules.py` 的核心契约——去重/排序/范围过滤、非法值跳过、禁选剔除、必选保留、上限截断时必选优先、下限回填优先级优先、min>max 钳制、limit 越界钳制。该模块覆盖率从 **11% → 96%**。问卷星侧对应模块早有完整单测，腾讯侧是缺口。
- **修复一个防御缺口**：`apply_multiple_constraints()` 原先对 `positive_priority_indices` 不做范围校验就直接参与「补足最少选择数」循环。若含越界索引（如 `[9, -3]`），循环会因计数达标提前退出，随后归一化又把越界项过滤掉，最终返回空列表、`min_required` 完全落空。现改为填充前先 `normalize_selected_indices` 归一化。当前两个调用方传的都是合法值，线上未触发，属纯防御性收紧。

## 影响

- 测试为纯新增；函数行为仅在「入参越界」这一此前未定义的场景下变化，正常配置路径的输出与之前完全一致。

## 解决的问题

Fixes #110

## 检查

- 新增用例单独跑：10 passed。
- 本地 `uv run python CI/python_ci.py` 全绿（compile / Ruff / Pyright / 全量单测）。